### PR TITLE
Added functionality to create an app role per Spring Boot application…

### DIFF
--- a/src/springboot.sh
+++ b/src/springboot.sh
@@ -15,8 +15,22 @@ sb::up() {
 	fi
 
 	horde::ensure_running mysql || return 1
-
 	horde::ensure_running logspout || return 1
+
+	docker run -it \
+		--rm \
+		--link vault:vault \
+		-v `pwd`:/mnt/creds \
+		-e VAULT_TOKEN=horde \
+		-e APP_NAME="${name}" \
+		vault:0.6.5  \
+		/bin/sh -c 'export VAULT_ADDR=http://$VAULT_PORT_8200_TCP_ADDR:8200; \
+					vault auth-enable approle; \
+					vault write auth/approle/role/$APP_NAME bind_secret_id=true; \
+					vault read -format=json auth/approle/role/$APP_NAME/role-id > ${APP_NAME}_roleId.json; \
+					vault write -f -format=json auth/approle/role/$APP_NAME/secret-id > ${APP_NAME}_secretId.json; \
+					mv *.json /mnt/creds;' \
+		|| return 1
 
 	docker run -d \
 		-P ${env_file_arg} \
@@ -30,8 +44,6 @@ sb::up() {
 		--link mysql:mysql \
 		"${image}" \
 		|| return 1
-	
-
 }
 
 sb_gw::up() {


### PR DESCRIPTION
…. The roleId and secretId are exported to JSON files that should be subsequently consumed by the app itself.