### PR TITLE
mysql service bugfix

### DIFF
--- a/src/plugins/services/mysql.service.sh
+++ b/src/plugins/services/mysql.service.sh
@@ -30,6 +30,6 @@ services::mysql::create_database() {
 	container::call run -it --rm \
 		--link mysql:mysql \
 		benschw/horde-mysql \
-		sh -c 'exec mysql -h$MYSQL_PORT_3306_TCP_ADDR -u admin -pchangeme -e "CREATE DATABASE IF NOT EXISTS '$dbname'"'
+		sh -c 'exec mysql -h$MYSQL_PORT_3306_TCP_ADDR -u admin -pchangeme -e "CREATE DATABASE IF NOT EXISTS '$db_name'"'
 
 }

--- a/src/plugins/services/mysql.service.sh
+++ b/src/plugins/services/mysql.service.sh
@@ -25,7 +25,7 @@ services::mysql() {
 }
 
 services::mysql::create_database() {
-	db_name="$1"
+	db_name="${1/-/_}"
 
 	container::call run -it --rm \
 		--link mysql:mysql \

--- a/src/plugins/services/mysql.service.sh
+++ b/src/plugins/services/mysql.service.sh
@@ -25,7 +25,7 @@ services::mysql() {
 }
 
 services::mysql::create_database() {
-	db_name="${1/-/_}"
+	db_name="${1//-/_}"
 
 	container::call run -it --rm \
 		--link mysql:mysql \


### PR DESCRIPTION
As the horde.json include dash into the service name and mysql recommend to use only basic Latin letters, digits 0-9, dollar, underscore in order to allow use unquote identifiers I recommend to replace dash by underscore.
I recommend as well fix the mistyped database name variable.