### PR TITLE
Added -cleanup flag to registrator container execution.

### DIFF
--- a/src/plugins/services/common.service.sh
+++ b/src/plugins/services/common.service.sh
@@ -30,7 +30,7 @@ services::registrator() {
 		--net=host \
 		--volume=/var/run/docker.sock:/tmp/docker.sock \
 		gliderlabs/registrator:latest \
-		-ip $ip consul://localhost:8500 || return 1
+		-ip $ip -cleanup consul://localhost:8500 || return 1
 }
 
 services::fabio() {


### PR DESCRIPTION
With this flag, if there are any dangling nodes in Consul (say, due to registrator being killed before the other services), registrator will purge them upon restart.